### PR TITLE
Reduce information_schema queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreliable 0.9.1 (November 21, 2022) ##
+
+### Changed
+
+* Improve efficiency by using ActiveRecord's SchemaCache.
+
 ## Unreliable 0.9.0 (November 20, 2022) ##
 
 ### Changed

--- a/lib/unreliable/build_order.rb
+++ b/lib/unreliable/build_order.rb
@@ -47,8 +47,11 @@ module Unreliable
     end
 
     def primary_key_columns(arel)
-      # primary_key returns a String if it's one column, an Array if two or more
-      [ActiveRecord::Base.connection.primary_key(arel.froms.first.name)].flatten
+      # primary_keys returns a String if it's one column, an Array if two or more.
+      # Using the SchemaCache minimizes the number of times we have to, e.g. in MySQL,
+      # SELECT column_name FROM information_schema.statistics
+      # (or in Rails < 6, SELECT column_name FROM information_schema.key_column_usage)
+      [ActiveRecord::Base.connection.schema_cache.primary_keys(arel.froms.first.name)].flatten
     end
 
     def order_columns(arel)

--- a/lib/unreliable/version.rb
+++ b/lib/unreliable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Unreliable
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
A test in an app that counted the number of SQL queries performed broke with v0.9.0 because it adds SELECTs on MySQL's information_schema table to determine primary keys. This change relies instead on ActiveRecord's SchemaCache, which as the name suggests tries to cache that information. It should return the gem to its pre-v0.9.0 efficiency.